### PR TITLE
fix junit version (set to 5.5.2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
 }
 
 bootJar {


### PR DESCRIPTION
Tests could not be executed with JUnit version 5.6.0.

Setting version back to 5.5.2